### PR TITLE
Show days greater than or equal to first display day

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -30,7 +30,7 @@ const attendance = useAttendance();
 
 const q = query(
   collection($firestore, "attendance").withConverter(AttendeeConverter),
-  where("date", ">", visibleDays.value.at(0)!.dateISO),
+  where("date", ">=", visibleDays.value.at(0)!.dateISO),
   where("date", "<=", visibleDays.value.at(-1)!.dateISO),
   orderBy("date"),
   orderBy("name")


### PR DESCRIPTION
Firestore query for attendees was excluding the first visible day, causing all entries for Monday to be invisible.